### PR TITLE
Introduce rules.neon

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ includes:
 
 Each rule can be enabled individually by adding it to your `phpstan.neon` or `phpstan.dist.neon` configuration file.
 
+If you prefer to includes all rules at once, you can include `rules.neon` instead:
+
+```yaml
+includes:
+    - vendor/kocal/phpstan-symfony-ux/rules.neon
+```
+
 ## LiveComponent Rules
 
 ### LiveActionMethodsVisibilityRule

--- a/rules.neon
+++ b/rules.neon
@@ -1,0 +1,15 @@
+rules:
+    - Kocal\PHPStanSymfonyUX\Rules\LiveComponent\LiveActionMethodsVisibilityRule
+    - Kocal\PHPStanSymfonyUX\Rules\LiveComponent\LiveListenerMethodsVisibilityRule
+    - Kocal\PHPStanSymfonyUX\Rules\LiveComponent\LivePropHydrationMethodsRule
+    - Kocal\PHPStanSymfonyUX\Rules\LiveComponent\LivePropModifierMethodRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\ClassMustBeFinalRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\ClassNameMustNotEndWithComponentRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\ExposePublicPropsMustBeFalseRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\ForbiddenAttributesPropertyRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\ForbiddenClassPropertyRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\ForbiddenReadonlyRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\MethodsVisibilityRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\PostMountMethodSignatureRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\PreMountMethodSignatureRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\PublicPropertiesMustBeCamelCaseRule


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | -

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.),
this will help people understand your PR.
-->
I’ve added an optional rules.neon file that allows you to enable all rules at once instead of configuring them individually. My motivation behind this change is to simplify setup, as in most cases users don’t need to manually register every rule from the PHPStan extension.